### PR TITLE
Adding Request imports in the documentation

### DIFF
--- a/source/docs/laravel/auth/quickstart.md
+++ b/source/docs/laravel/auth/quickstart.md
@@ -91,6 +91,8 @@ that have a unique value per user.
 In this example we want to use the users `mail` LDAP attribute to sign them into our application.
 
 ```php
+use Illuminate\Http\Request;
+
 class LoginController extends Controller
 {
     // ...
@@ -253,6 +255,8 @@ that have a unique value per user.
 In this example we want to use the users `mail` LDAP attribute to sign them into our application.
 
 ```php
+use Illuminate\Http\Request;
+
 class LoginController extends Controller
 {
     // ...

--- a/source/docs/laravel/auth/usage.md
+++ b/source/docs/laravel/auth/usage.md
@@ -45,6 +45,8 @@ To have LdapRecord properly locate the user in your directory, we will override 
 ```php
 // app/Http/Controllers/Auth/LoginController.php
 
+use Illuminate\Http\Request;
+
 protected function credentials(Request $request)
 {
     return [
@@ -128,6 +130,8 @@ We do this by overriding the `username` method, and updating our `credentials` m
 
 ```php
 // app/Http/Controllers/Auth/LoginController.php
+
+use Illuminate\Http\Request;
 
 public function username()
 {

--- a/source/docs/laravel/debugging.md
+++ b/source/docs/laravel/debugging.md
@@ -78,6 +78,8 @@ and the `credentials` method on your `LoginController`
 ```php
 // app/Http/Controllers/Auth/LoginController.php
 
+use Illuminate\Http\Request;
+
 public function username()
 {
     // This is the name of the HTML 'input' inside


### PR DESCRIPTION
Hi Steve,
following the documentation, if you don´t add the import when override the `credentials` method, Laravel display this error:

![image](https://user-images.githubusercontent.com/6285255/80980977-9bfbdf80-8e29-11ea-8a4c-4033cd331667.png)

But it´s incorrect. The correct import is `use Illuminate\Http\Request;`
I simply added to the documentation.. :)